### PR TITLE
[Step17] 카프카 설정 및 연결 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.5.0'
 
+    implementation("org.springframework.kafka:spring-kafka")
+
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 
@@ -45,6 +47,9 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    testImplementation("org.springframework.kafka:spring-kafka-test")
+
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+services:
+  zookeeper:
+    image: 'confluentinc/cp-zookeeper:latest'
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: 'confluentinc/cp-kafka:latest'
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  redis:
+    image: redis:latest  # Redis 최신 이미지를 사용
+    container_name: redis-server  # 컨테이너 이름 설정
+    ports:
+      - "6379:6379"  # 호스트와 컨테이너 간의 포트 매핑

--- a/src/main/kotlin/kr/com/hhp/concertreservationapiserver/common/domain/message/SendMessage.kt
+++ b/src/main/kotlin/kr/com/hhp/concertreservationapiserver/common/domain/message/SendMessage.kt
@@ -1,4 +1,4 @@
-package kr.com.hhp.concertreservationapiserver.common.domain
+package kr.com.hhp.concertreservationapiserver.common.domain.message
 
 import kr.com.hhp.concertreservationapiserver.common.domain.event.SendMessageChannel
 

--- a/src/main/kotlin/kr/com/hhp/concertreservationapiserver/common/infra/message/SlackSendMessage.kt
+++ b/src/main/kotlin/kr/com/hhp/concertreservationapiserver/common/infra/message/SlackSendMessage.kt
@@ -1,9 +1,9 @@
-package kr.com.hhp.concertreservationapiserver.common.infra.slack
+package kr.com.hhp.concertreservationapiserver.common.infra.message
 
 import com.slack.api.Slack
 import com.slack.api.methods.SlackApiException
 import com.slack.api.methods.request.chat.ChatPostMessageRequest
-import kr.com.hhp.concertreservationapiserver.common.domain.SendMessage
+import kr.com.hhp.concertreservationapiserver.common.domain.message.SendMessage
 import kr.com.hhp.concertreservationapiserver.common.domain.event.SendMessageChannel
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -13,7 +13,7 @@ import java.io.IOException
 @Component
 class SlackSendMessage(@Value("\${slack.token}") private val token: String) : SendMessage {
 
-    private val log = LoggerFactory.getLogger(SlackSendMessage::class.java)
+    private val log = LoggerFactory.getLogger(this::class.java)
 
     override fun send(channel: SendMessageChannel, message: String) {
         val channelAddress = when (channel) {

--- a/src/main/kotlin/kr/com/hhp/concertreservationapiserver/common/presentation/event/SendMessageEventListener.kt
+++ b/src/main/kotlin/kr/com/hhp/concertreservationapiserver/common/presentation/event/SendMessageEventListener.kt
@@ -1,6 +1,6 @@
 package kr.com.hhp.concertreservationapiserver.common.presentation.event
 
-import kr.com.hhp.concertreservationapiserver.common.domain.SendMessage
+import kr.com.hhp.concertreservationapiserver.common.domain.message.SendMessage
 import kr.com.hhp.concertreservationapiserver.common.domain.event.SendMessageEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component

--- a/src/main/kotlin/kr/com/hhp/concertreservationapiserver/concert/business/domain/service/ConcertService.kt
+++ b/src/main/kotlin/kr/com/hhp/concertreservationapiserver/concert/business/domain/service/ConcertService.kt
@@ -41,7 +41,7 @@ class ConcertService(
 
     // 예약 가능 좌석 조회
     fun getAllAvailableReservationSeat(concertDetailId: Long): List<ConcertSeatEntity> {
-        val concertDetail = concertDetailRepository.findByConcertDetailId(concertDetailId)
+        concertDetailRepository.findByConcertDetailId(concertDetailId)
             ?: throw CustomException(ErrorCode.CONCERT_DETAIL_NOT_FOUND)
 
         return concertSeatRepository.findAllByConcertDetailIdAndReservationStatus(

--- a/src/main/kotlin/kr/com/hhp/concertreservationapiserver/concert/infra/event/ConcertEventKafkaProducer.kt
+++ b/src/main/kotlin/kr/com/hhp/concertreservationapiserver/concert/infra/event/ConcertEventKafkaProducer.kt
@@ -1,0 +1,26 @@
+package kr.com.hhp.concertreservationapiserver.concert.infra.event
+
+import kr.com.hhp.concertreservationapiserver.concert.business.domain.event.ConcertEvent
+import kr.com.hhp.concertreservationapiserver.concert.business.domain.event.ConcertEventPublisher
+import org.springframework.context.annotation.Primary
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+@Primary
+@Component
+class ConcertEventKafkaProducer(private val kafkaTemplate: KafkaTemplate<String, Any>): ConcertEventPublisher {
+
+    override fun publishReservationEvent(concertSeatId: Long) {
+        kafkaTemplate.send("concertReservation", ConcertEvent.Reservation(concertSeatId))
+    }
+
+    override fun publishPaymentEvent(concertSeatId: Long, userId: Long, price: Int, walletId: Long, token: String) {
+        kafkaTemplate.send("concertPay", ConcertEvent.Pay(
+            walletId = walletId,
+            userId = userId,
+            price = price,
+            concertSeatId = concertSeatId,
+            token = token
+        ))
+    }
+}

--- a/src/main/kotlin/kr/com/hhp/concertreservationapiserver/concert/presentation/event/ConcertReservationConsumer.kt
+++ b/src/main/kotlin/kr/com/hhp/concertreservationapiserver/concert/presentation/event/ConcertReservationConsumer.kt
@@ -1,0 +1,28 @@
+package kr.com.hhp.concertreservationapiserver.concert.presentation.event
+
+import kr.com.hhp.concertreservationapiserver.concert.business.application.ConcertFacade
+import kr.com.hhp.concertreservationapiserver.concert.business.domain.event.ConcertEvent
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+
+@Component
+class ConcertReservationConsumer(private val concertFacade: ConcertFacade) {
+
+    @KafkaListener(topics = ["concertReservation"])
+    fun listen(event: ConcertEvent.Reservation) {
+        // 콘서트 임시 예약 이후 처리
+        concertFacade.reserveSeat(concertSeatId = event.concertSeatId)
+    }
+
+    @KafkaListener(topics = ["concertPay"])
+    fun listen(event: ConcertEvent.Pay) {
+        // 콘서트 임시 예약 이후 처리
+        concertFacade.paymentSeat(
+            concertSeatId = event.concertSeatId,
+            walletId = event.walletId,
+            userId = event.userId,
+            price = event.price,
+            token = event.token
+        )
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  profiles:
+    active: slack
+
   application:
     name:
       concert-reservation-api-server
@@ -16,8 +19,26 @@ spring:
 #      ddl-auto: create
     show-sql: true
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: group_id
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: '*'
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+
 springdoc:
   api-docs:
     path: /api-docs
   swagger-ui:
     path: /swagger-ui.html
+
+
+
+

--- a/src/test/kotlin/kr/com/hhp/concertreservationapiserver/integration/ConcertKafkaIntegrationTest.kt
+++ b/src/test/kotlin/kr/com/hhp/concertreservationapiserver/integration/ConcertKafkaIntegrationTest.kt
@@ -1,0 +1,86 @@
+package kr.com.hhp.concertreservationapiserver.integration
+
+import kr.com.hhp.concertreservationapiserver.concert.business.domain.event.ConcertEvent
+import kr.com.hhp.concertreservationapiserver.concert.infra.event.ConcertEventKafkaProducer
+import kr.com.hhp.concertreservationapiserver.concert.presentation.event.ConcertReservationConsumer
+import kr.com.hhp.concertreservationapiserver.token.business.domain.service.TokenQueueService
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.given
+import org.mockito.kotlin.then
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.boot.test.mock.mockito.SpyBean
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertTrue
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, brokerProperties = ["listeners=PLAINTEXT://localhost:9092", "port=9092"])
+class ConcertKafkaIntegrationTest {
+
+    @Autowired
+    lateinit var concertEventKafkaProducer: ConcertEventKafkaProducer
+
+    @SpyBean
+    lateinit var concertReservationConsumer: ConcertReservationConsumer
+
+    @MockBean
+    lateinit var tokenQueueService: TokenQueueService
+
+    @Test
+    fun `콘서트 좌석 임시 예약 카프카 테스트`() {
+        // given
+        val concertSeatId = 1L
+        val latch = CountDownLatch(1)
+
+        val reservation = ConcertEvent.Reservation(concertSeatId)
+
+        given(concertReservationConsumer.listen(reservation)).willAnswer { latch.countDown() }
+
+        // when
+        concertEventKafkaProducer.publishReservationEvent(concertSeatId)
+
+        // then
+        val messageConsumed = latch.await(5, TimeUnit.SECONDS)
+        assertTrue(messageConsumed, "메시지가 소비되지 않았습니다.")
+        then(concertReservationConsumer).should().listen(reservation)
+    }
+
+
+    @Test
+    fun `콘서트 좌석 결제 카프카 테스트`() {
+        // given
+        val concertSeatId = 1L
+        val walletId = 1L
+        val userId = 1L
+        val price = 50000
+        val token = UUID.randomUUID().toString()
+
+        val latch = CountDownLatch(1)
+
+        val pay = ConcertEvent.Pay(
+            concertSeatId = concertSeatId, walletId = walletId, userId = userId, price = price, token = token
+        )
+
+        given(concertReservationConsumer.listen(pay)).willAnswer { latch.countDown() }
+        doNothing().whenever(tokenQueueService).deleteActiveToken(token)
+
+        // when
+        concertEventKafkaProducer.publishPaymentEvent(
+            concertSeatId = concertSeatId, userId = userId, price = price, walletId = walletId, token = token
+        )
+
+        // then
+        val messageConsumed = latch.await(5, TimeUnit.SECONDS)
+        assertTrue(messageConsumed, "메시지가 소비되지 않았습니다.")
+        then(concertReservationConsumer).should().listen(pay)
+    }
+}


### PR DESCRIPTION
### 작업 내용
 - Kafka 적용
 - 기존 ApplicationEvent -> Kafka로 변경
 - Kafka 메시지 발행 및 소비 테스트코드 작성
 - docker-compose 작성 (Kafka, redis 실행)
![image](https://github.com/user-attachments/assets/6919fb10-fb75-4e32-9b73-446c04bb8322)